### PR TITLE
systemd configuration for multi service && cmake configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,6 @@ target_link_libraries(multi_client ${LIBYAML_LIBRARIES})
 target_link_libraries(multi_client ${LIBIW_LIBRARY})
 target_link_libraries(multi_client ${CMAKE_THREAD_LIBS_INIT})
 install(TARGETS multi_client RUNTIME DESTINATION /usr/local/sbin)
-install(FILES ${PROJECT_SOURCE_DIR}/files/multi-upstart.init DESTINATION
-        /etc/init/ PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-        RENAME multi.conf)
+install(FILES ${PROJECT_SOURCE_DIR}/files/multi-systemd.init DESTINATION
+        /lib/systemd/system/ PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+        RENAME multi.service)

--- a/src/files/multi-systemd.init
+++ b/src/files/multi-systemd.init
@@ -1,0 +1,12 @@
+[Unit]
+Description=Multi network manager
+After=network.target
+
+[Service]
+ExecStart=/usr/local/sbin/multi_client
+Type=simple
+Restart=on-failure
+
+# 'sshd -D' leaks stderr and confuses things in conjunction with 'console log'
+StandardError=null
+StandardOutput=null

--- a/src/files/postinst
+++ b/src/files/postinst
@@ -3,5 +3,5 @@
 #/usr/sbin/update-rc.d multi defaults
 #/etc/init.d/multi restart
 
-initctl reload-configuration
-initctl start multi
+systemctl reload multi
+systemctl start multi

--- a/src/files/postinst
+++ b/src/files/postinst
@@ -3,5 +3,4 @@
 #/usr/sbin/update-rc.d multi defaults
 #/etc/init.d/multi restart
 
-systemctl reload multi
 systemctl start multi

--- a/src/files/prerm
+++ b/src/files/prerm
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-initctl stop multi
-initctl reload-configuration
+systemctl stop multi
+systemctl reload multi

--- a/src/files/prerm
+++ b/src/files/prerm
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 systemctl stop multi
-systemctl reload multi


### PR DESCRIPTION
Basic translation of the upstart file to systemd,
cmake files altered to run the equivalent systemctl commands, instead of initctl.

You may want to confirm whether Type=simple will work for you. Ref http://www.freedesktop.org/software/systemd/man/systemd.service.html