### PR TITLE
Install section required to allow enable/disable

### DIFF
--- a/src/files/multi-systemd.init
+++ b/src/files/multi-systemd.init
@@ -10,3 +10,6 @@ Restart=on-failure
 # 'sshd -D' leaks stderr and confuses things in conjunction with 'console log'
 StandardError=null
 StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
systemctl enable requires an [Install] section to be present.
service fails to start on boot without this section.