### PR TITLE
Ft iprules sanity check

### DIFF
--- a/src/multi_link_core.c
+++ b/src/multi_link_core.c
@@ -80,6 +80,8 @@ extern void multi_link_free_ip_info(struct ip_info *ip_info);
 //multi_dhcp_main
 extern void* multi_dhcp_main(void *arg); 
 
+static void multi_link_del_info(struct filter_list nlmsg_list, uint16_t nlmsg_type);
+
 int32_t multi_link_filter(uint32_t seq, mnl_cb_t cb, void *arg){
     uint8_t buf[MNL_SOCKET_BUFFER_SIZE];
     int32_t ret;
@@ -96,7 +98,7 @@ int32_t multi_link_filter(uint32_t seq, mnl_cb_t cb, void *arg){
         ret = mnl_socket_recvfrom(multi_link_nl_request, buf, sizeof(buf));
     }
 
-    return 1;
+    return ret;
 }
 
 
@@ -163,6 +165,59 @@ static uint8_t multi_link_check_unique(struct multi_link_info *li,
     return unique;
 }
 
+//Addresses and routes are always deleted when an interface goes down, but not
+//rules. Netlink is not reliable and there are scenarios where we will loose
+//messages and not clean up properly. We therefore need to make sure that there
+//exists no rules poining to this address/interface
+static int32_t multi_link_rules_sanity(struct multi_link_info *li)
+{
+    struct ip_info ip_info;
+    uint8_t buf[MNL_SOCKET_BUFFER_SIZE];
+    struct nlmsghdr *nlh;
+    struct rtgenmsg *rt;
+    uint32_t seq;
+    int32_t ret;
+
+    memset(buf, 0, MNL_SOCKET_BUFFER_SIZE);
+    memset(&ip_info, 0, sizeof(ip_info));
+
+    //I am lazy and will use ip_info for now
+    TAILQ_INIT(&(ip_info.ip_rules_n));
+    ip_info.data = li;
+
+    //Sets room for one nlmsghdr in buffer buf
+    nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = RTM_GETRULE;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    nlh->nlmsg_seq = seq = time(NULL);
+    rt = mnl_nlmsg_put_extra_header(nlh, sizeof(struct rtgenmsg));
+    rt->rtgen_family = AF_INET; //Multi only supports v4
+
+    if(mnl_socket_sendto(multi_link_nl_request, nlh, nlh->nlmsg_len) < 0){
+        MULTI_DEBUG_PRINT_SYSLOG(stderr, "Cannot request rules dump\n");
+        return EXIT_FAILURE;
+    }
+
+    ret = multi_link_filter(seq, multi_link_filter_iprules_addr, &ip_info);
+
+    if (ret) {
+        //Some rules might have been added
+        multi_link_free_ip_info(&ip_info);
+        MULTI_DEBUG_PRINT_SYSLOG(stderr, "Sanity check failed (memory)\n");
+        return EXIT_FAILURE;
+    }
+
+    if (!ip_info.ip_rules_n.tqh_first)
+        return EXIT_SUCCESS;
+
+    MULTI_DEBUG_PRINT_SYSLOG(stderr, "Will delete dirty rules\n");
+
+    multi_link_del_info(ip_info.ip_rules_n, RTM_DELRULE);
+    multi_link_free_ip_info(&ip_info);
+
+    return EXIT_SUCCESS;
+}
+
 static void multi_link_check_link(void *data, void *user_data){
     struct multi_link_info *li = (struct multi_link_info *) data;
     struct multi_config *mc = (struct multi_config *) user_data;
@@ -185,6 +240,9 @@ static void multi_link_check_link(void *data, void *user_data){
             pthread_mutex_unlock(&(li->state_lock));
             return;
         }
+
+        /* Check for leftover rules  */
+        multi_link_rules_sanity(li);
 
         //TODO: Add error checks!
         multi_link_configure_link(li);
@@ -662,13 +720,11 @@ static int32_t multi_link_event_loop(struct multi_config *mc){
     if(mnl_socket_bind(multi_link_nl_request, 0, MNL_SOCKET_AUTOPID) < 0){
         MULTI_DEBUG_PRINT_SYSLOG(stderr, "Could not bind mnl event socket\n");
         mnl_socket_close(multi_link_nl_event);
-        mnl_socket_close(multi_link_nl_event);
         return EXIT_FAILURE;
     }
 
     if(mnl_socket_bind(multi_link_nl_set, 0, MNL_SOCKET_AUTOPID) < 0){
         MULTI_DEBUG_PRINT_SYSLOG(stderr, "Could not bind mnl event socket\n");
-        mnl_socket_close(multi_link_nl_event);
         mnl_socket_close(multi_link_nl_event);
         return EXIT_FAILURE;
     }
@@ -676,7 +732,6 @@ static int32_t multi_link_event_loop(struct multi_config *mc){
     if(mnl_socket_bind(multi_link_nl_event, RTMGRP_LINK, MNL_SOCKET_AUTOPID) 
             < 0){
         MULTI_DEBUG_PRINT_SYSLOG(stderr, "Could not bind mnl event socket\n");
-        mnl_socket_close(multi_link_nl_event);
         mnl_socket_close(multi_link_nl_event);
         return EXIT_FAILURE;
     }

--- a/src/multi_link_core.c
+++ b/src/multi_link_core.c
@@ -193,6 +193,8 @@ static int32_t multi_link_rules_sanity(struct multi_link_info *li)
     rt = mnl_nlmsg_put_extra_header(nlh, sizeof(struct rtgenmsg));
     rt->rtgen_family = AF_INET; //Multi only supports v4
 
+    MULTI_DEBUG_PRINT_SYSLOG(stderr, "Will check for dirty rules\n");
+
     if(mnl_socket_sendto(multi_link_nl_request, nlh, nlh->nlmsg_len) < 0){
         MULTI_DEBUG_PRINT_SYSLOG(stderr, "Cannot request rules dump\n");
         return EXIT_FAILURE;

--- a/src/multi_link_filter.c
+++ b/src/multi_link_filter.c
@@ -316,6 +316,47 @@ int32_t multi_link_filter_iprules(const struct nlmsghdr *nlh, void *data){
     return MNL_CB_OK;
 }
 
+//Create a list of rules matching the given source address
+int32_t multi_link_filter_iprules_addr(const struct nlmsghdr *nlh, void *data)
+{
+    struct ip_info *ip_info = (struct ip_info *) data;
+    struct rtmsg *rt = mnl_nlmsg_get_payload(nlh);
+    struct nlattr *tb[FRA_MAX + 1] = {};
+    char *iface_name = NULL;
+    struct filter_msg *msg;
+    uint32_t rule_addr;
+    struct multi_link_info *li = ip_info->data;
+
+    mnl_attr_parse(nlh, sizeof(*rt), multi_link_fill_rtattr, tb);
+
+    if (!tb[FRA_PRIORITY])
+        return MNL_CB_OK;
+
+    if ((!tb[FRA_SRC] && !tb[FRA_DST]) || (tb[FRA_SRC] && tb[FRA_DST]))
+        return MNL_CB_OK;
+
+    if (tb[FRA_SRC])
+        rule_addr = mnl_attr_get_u32(tb[FRA_SRC]);
+    else
+        rule_addr = mnl_attr_get_u32(tb[FRA_DST]);
+
+    if (rule_addr != li->cfg.address.s_addr)
+        return MNL_CB_OK;
+
+    //Add check for other IPs
+    msg = (struct filter_msg*) malloc(nlh->nlmsg_len +
+            sizeof(TAILQ_ENTRY(filter_msg)));
+
+    if (msg == NULL) {
+        MULTI_DEBUG_PRINT_SYSLOG(stderr, "Can't allocate memory for rule message\n");
+        return MNL_CB_ERROR;
+    }
+
+    memcpy(&(msg->nlh), nlh, nlh->nlmsg_len);
+    TAILQ_INSERT_TAIL(&(ip_info->ip_rules_n), msg, list_ptr);
+    return MNL_CB_OK;
+}
+
 int32_t multi_link_filter_iproutes(const struct nlmsghdr *nlh, void *data){
     struct ip_info *ip_info = (struct ip_info *) data;
     struct rtmsg *table_i = mnl_nlmsg_get_payload(nlh);

--- a/src/multi_link_filter.c
+++ b/src/multi_link_filter.c
@@ -347,15 +347,19 @@ int32_t multi_link_filter_iprules_addr(const struct nlmsghdr *nlh, void *data)
 
     //Need to check if there exists an interface with this IP using this table
     for (li_itr = multi_link_links_2.lh_first; li_itr != NULL; ){
-        if (li_itr->cfg.address.s_addr == rule_addr &&
+        if (li != li_itr &&
+            li_itr->cfg.address.s_addr == rule_addr &&
             li_itr->metric == target_table)
             break;
 
         li_itr = li_itr->next.le_next;
     }
 
-    if (li_itr != NULL)
+    if (li_itr != NULL) {
+        MULTI_DEBUG_PRINT_SYSLOG(stderr, "Ignore (sanity) rule pref %u table %u\n",
+                mnl_attr_get_u32(tb[FRA_PRIORITY]), target_table);
         return MNL_CB_OK;
+    }
 
     //Add check for other IPs
     msg = (struct filter_msg*) malloc(nlh->nlmsg_len +

--- a/src/multi_link_filter.c
+++ b/src/multi_link_filter.c
@@ -324,12 +324,17 @@ int32_t multi_link_filter_iprules_addr(const struct nlmsghdr *nlh, void *data)
     struct nlattr *tb[FRA_MAX + 1] = {};
     char *iface_name = NULL;
     struct filter_msg *msg;
-    uint32_t target_table, rule_addr;
+    uint32_t target_table, rule_addr, prio;
     struct multi_link_info *li = ip_info->data, *li_itr;
 
     mnl_attr_parse(nlh, sizeof(*rt), multi_link_fill_rtattr, tb);
 
     if (!tb[FRA_PRIORITY] || !tb[FRA_TABLE])
+        return MNL_CB_OK;
+
+    prio = mnl_attr_get_u32(tb[FRA_PRIORITY]);
+
+    if (prio != ADDR_RULE_PRIO && prio != NW_RULE_PRIO)
         return MNL_CB_OK;
 
     if ((!tb[FRA_SRC] && !tb[FRA_DST]) || (tb[FRA_SRC] && tb[FRA_DST]))

--- a/src/multi_link_filter.h
+++ b/src/multi_link_filter.h
@@ -37,6 +37,7 @@ struct ip_info{
     struct filter_list ip_addr_n; //The nlmsgs, will be used to delete ip addresses
     struct filter_list ip_rules_n; //The netlink messages containing the rules
     struct filter_list ip_routes_n; //The table ID
+    void *data; //Pointer that can be used to store private data
 };
 
 //Helper function for filling in rtattr
@@ -45,6 +46,7 @@ uint8_t multi_link_check_wlan_mode(uint8_t *dev_name);
 int32_t multi_link_filter_links(const struct nlmsghdr *nlh, void *data);
 int32_t multi_link_filter_ipaddr(const struct nlmsghdr *nlh, void *data);
 int32_t multi_link_filter_iprules(const struct nlmsghdr *nlh, void *data);
+int32_t multi_link_filter_iprules_addr(const struct nlmsghdr *nlh, void *data);
 int32_t multi_link_filter_iproutes(const struct nlmsghdr *nlh, void *arg);
 int32_t multi_link_filter_ppp(const struct nlmsghdr *nlh, void *data);
 int32_t multi_link_filter_ap(const struct nlmsghdr *nlh, void *data);

--- a/src/multi_multicast.c
+++ b/src/multi_multicast.c
@@ -136,7 +136,6 @@ void multi_test_visible_loop(struct multi_config *mc){
         //Repeat every UP message
         if(retval == 0){
             for(ni = iface_list.lh_first; ni != NULL; ni = ni->next.le_next){
-                printf("Hei\n");
                 iov.iov_base = (void *) ni->nlmsg;
                 iov.iov_len = ni->nlmsg->nlmsg_len;
                 sendmsg(netlink_sock, &msg, 0);


### PR DESCRIPTION
There are a number of reasons for why netlink messages might get lost, it is
after all an unreliable protocol. When a link is deleted, address and routes are
deleted by the kernel. However, we are responsible for deleting the rule. If
this for some reason should fail (or DELLINK is lost), we might be left with a
rule pointing to an incorrect routing table. This is not good. So whenever an
interface comes up, check for any rules matching the address (either source or
destination) and delete that rule.

Works with multiple interfaces with the same IPs. The 90000+ rules are left for now, until I decide on a nice way to detect and delete false ones.